### PR TITLE
[Registry] Introduce basic registry access helpers

### DIFF
--- a/include/wil/registry.h
+++ b/include/wil/registry.h
@@ -52,8 +52,6 @@ namespace wil
     }
 #endif // WIL_ENABLE_EXCEPTIONS
 
-    // TODO: support "any" function that deduces type?
-
     inline HRESULT get_registry_dword_nothrow(HKEY hkey, LPCWSTR subkey, LPCWSTR regValueName, _Out_ DWORD* value) noexcept
     {
         DWORD size{sizeof(value)};
@@ -68,7 +66,7 @@ namespace wil
     namespace details
     {
         template <typename err_policy, typename result = err_policy::result>
-        result set_registry_dword(HKEY hkey, LPCWSTR subkey, LPCWSTR regValueName, DWORD value)
+        inline result set_registry_dword(HKEY hkey, LPCWSTR subkey, LPCWSTR regValueName, DWORD value)
         {
             // TODO: support little endian and big endian?
             const auto hr = HRESULT_FROM_WIN32(::RegSetKeyValueW(hkey, subkey, regValueName, REG_DWORD, &value, sizeof(value)));
@@ -107,7 +105,7 @@ namespace wil
         };
 
         template <typename policy, typename result_t = policy::result>
-        result_t get_registry_dword(HKEY hkey, LPCWSTR subkey = nullptr, LPCWSTR regValueName = nullptr)
+        inline result_t get_registry_dword(HKEY hkey, LPCWSTR subkey = nullptr, LPCWSTR regValueName = nullptr)
         {
             DWORD value{};
             const auto result = get_registry_dword_nothrow(hkey, subkey, regValueName, &value);
@@ -120,6 +118,7 @@ namespace wil
         }
 
 #if defined(_STRING_)
+        // std::string.resize() can throw, so this requires exceptions.
         template<typename policy, typename result_t = policy::result>
         result_t get_registry_string(HKEY hkey, LPCWSTR subkey = nullptr, LPCWSTR regValueName = nullptr)
         {
@@ -169,7 +168,7 @@ namespace wil
     namespace details
     {
         template <typename err_policy, typename result = err_policy::result>
-        result set_registry_string(HKEY hkey, LPCWSTR subkey, LPCWSTR regValueName, const std::wstring& value)
+        inline result set_registry_string(HKEY hkey, LPCWSTR subkey, LPCWSTR regValueName, const std::wstring& value)
         {
             static_assert(wistd::is_same_v<std::wstring::value_type, wchar_t>, "We assume a wstring is made of wchar_ts");
 

--- a/include/wil/registry.h
+++ b/include/wil/registry.h
@@ -85,14 +85,14 @@ namespace wil
     /// @cond
     namespace details
     {
-#if defined(_OPTIONAL_)
+#if _HAS_CXX17 && defined(_OPTIONAL_)
         template <typename Result>
         struct optional_registry_policy
         {
             typedef std::optional<Result> result;
             __forceinline static result NotFound() { return std::nullopt; }
         };
-#endif // defined(_OPTIONAL_)
+#endif // _HAS_CXX17 && defined(_OPTIONAL_)
 
         template<typename Result>
         struct required_registry_policy
@@ -149,15 +149,15 @@ namespace wil
     }
     /// @endcond
 
-#if defined(_OPTIONAL_)
+#if _HAS_CXX17 && defined(_OPTIONAL_)
     constexpr auto* try_get_registry_dword = details::get_registry_dword<details::optional_registry_policy<DWORD>>;
-#endif // defined(_OPTIONAL_)
+#endif // _HAS_CXX17 && defined(_OPTIONAL_)
     constexpr auto* get_registry_dword = details::get_registry_dword<details::required_registry_policy<DWORD>>;
 
 #if defined(_STRING_)
-#if defined(_OPTIONAL_)
+#if _HAS_CXX17 &&  defined(_OPTIONAL_)
     constexpr auto* try_get_registry_string = details::get_registry_string<details::optional_registry_policy<std::wstring>>;
-#endif // defined(_OPTIONAL_)
+#endif // _HAS_CXX17 && defined(_OPTIONAL_)
     constexpr auto* get_registry_string = details::get_registry_string<details::required_registry_policy<std::wstring>>;
 #endif // defined(_STRING_)
 

--- a/include/wil/registry.h
+++ b/include/wil/registry.h
@@ -175,7 +175,7 @@ namespace wil
 
             // TODO: where does the +1 go?
             // TODO: check for DWORD/size_t overflow?
-            const DWORD byteSize = (static_cast<DWORD>(value.size()) + 1) * sizeof(wchar_t);
+            const DWORD byteSize = (static_cast<DWORD>(value.size()) * sizeof(wchar_t)) + 1;
             const auto hr = HRESULT_FROM_WIN32(::RegSetKeyValueW(hkey, subkey, regValueName, REG_SZ, value.c_str(), byteSize));
             return err_policy::HResult(hr);
         }

--- a/tests/BasicRegistryTests.cpp
+++ b/tests/BasicRegistryTests.cpp
@@ -1,6 +1,8 @@
 
 #include <string>
+#if _HAS_CXX17
 #include <optional>
+#endif // _HAS_CXX17
 #include <wil/filesystem.h>
 #include <wil/registry.h>
 #include <wil/resource.h>
@@ -53,6 +55,7 @@ TEST_CASE("BasicRegistryTests::Dwords", "[registry][get_registry_dword]")
         }
     }
 
+#if defined(_OPTIONAL_)
     SECTION("get optional with string key and value name")
     {
         const auto emptyResult = wil::try_get_registry_dword(HKEY_CURRENT_USER, testSubkey, L"NonExistentKey");
@@ -66,6 +69,7 @@ TEST_CASE("BasicRegistryTests::Dwords", "[registry][get_registry_dword]")
             REQUIRE(result == value);
         }
     }
+#endif // defined(_OPTIONAL_)
 #endif
 
     SECTION("get and set with string key and DEFAULT value name, nothrow")
@@ -99,6 +103,7 @@ TEST_CASE("BasicRegistryTests::Dwords", "[registry][get_registry_dword]")
         }
     }
 
+#if defined(_OPTIONAL_)
     SECTION("get optional with string key and DEFAULT value name")
     {
         const auto emptyResult = wil::try_get_registry_dword(HKEY_CURRENT_USER, testSubkey, nullptr);
@@ -112,6 +117,7 @@ TEST_CASE("BasicRegistryTests::Dwords", "[registry][get_registry_dword]")
             REQUIRE(result == value);
         }
     }
+#endif // defined(_OPTIONAL_)
 #endif
 }
 
@@ -177,6 +183,7 @@ TEST_CASE("BasicRegistryTests::Strings", "[registry][get_registry_string]")
         }
     }
 
+#if defined(_OPTIONAL_)
     SECTION("get optional with string key and DEFAULT value name")
     {
         const auto emptyResult = wil::try_get_registry_string(HKEY_CURRENT_USER, testSubkey, nullptr);
@@ -190,5 +197,6 @@ TEST_CASE("BasicRegistryTests::Strings", "[registry][get_registry_string]")
             REQUIRE(result == value);
         }
     }
+#endif // defined(_OPTIONAL_)
 }
 #endif

--- a/tests/BasicRegistryTests.cpp
+++ b/tests/BasicRegistryTests.cpp
@@ -1,0 +1,79 @@
+
+#include <wil/filesystem.h>
+#include <wil/registry.h>
+#include <wil/resource.h>
+
+#include <memory> // For shared_event_watcher
+#include <wil/resource.h>
+
+#include "common.h"
+
+constexpr auto testSubkey = L"Software\\Microsoft\\RegistryWatcherTest";
+constexpr auto dwordValueName = L"MyDwordValue";
+
+TEST_CASE("BasicRegistryTests::Dwords", "[registry][get_registry_dword]")
+{
+    SECTION("get and set with string key and value name, nothrow")
+    {
+        DWORD value = 4;
+        REQUIRE_SUCCEEDED(wil::set_registry_dword_nothrow(HKEY_CURRENT_USER, testSubkey, dwordValueName, value));
+
+        DWORD result{ 0 };
+        REQUIRE_SUCCEEDED(wil::get_registry_dword_nothrow(HKEY_CURRENT_USER, testSubkey, dwordValueName, &result));
+        REQUIRE(result == value);
+
+        value = 1;
+        REQUIRE_SUCCEEDED(wil::set_registry_dword_nothrow(HKEY_CURRENT_USER, testSubkey, dwordValueName, value));
+        REQUIRE_SUCCEEDED(wil::get_registry_dword_nothrow(HKEY_CURRENT_USER, testSubkey, dwordValueName, &result));
+        REQUIRE(result == value);
+
+        value = 0;
+        REQUIRE_SUCCEEDED(wil::set_registry_dword_nothrow(HKEY_CURRENT_USER, testSubkey, dwordValueName, value));
+        REQUIRE_SUCCEEDED(wil::get_registry_dword_nothrow(HKEY_CURRENT_USER, testSubkey, dwordValueName, &result));
+        REQUIRE(result == value);
+    }
+
+#ifdef WIL_ENABLE_EXCEPTIONS
+    SECTION("get and set with string key and value name")
+    {
+        for (DWORD&& value : { 4, 1, 0 })
+        {
+            wil::set_registry_dword(HKEY_CURRENT_USER, testSubkey, dwordValueName, value);
+            const auto result = wil::get_registry_dword(HKEY_CURRENT_USER, testSubkey, dwordValueName);
+            REQUIRE(result == value);
+        }
+    }
+#endif
+
+    SECTION("get and set with string key and DEFAULT value name, nothrow")
+    {
+        DWORD value = 4;
+        REQUIRE_SUCCEEDED(wil::set_registry_dword_nothrow(HKEY_CURRENT_USER, testSubkey, nullptr, value));
+
+        DWORD result{ 0 };
+        REQUIRE_SUCCEEDED(wil::get_registry_dword_nothrow(HKEY_CURRENT_USER, testSubkey, nullptr, &result));
+        REQUIRE(result == value);
+
+        value = 1;
+        REQUIRE_SUCCEEDED(wil::set_registry_dword_nothrow(HKEY_CURRENT_USER, testSubkey, nullptr, value));
+        REQUIRE_SUCCEEDED(wil::get_registry_dword_nothrow(HKEY_CURRENT_USER, testSubkey, nullptr, &result));
+        REQUIRE(result == value);
+
+        value = 0;
+        REQUIRE_SUCCEEDED(wil::set_registry_dword_nothrow(HKEY_CURRENT_USER, testSubkey, nullptr, value));
+        REQUIRE_SUCCEEDED(wil::get_registry_dword_nothrow(HKEY_CURRENT_USER, testSubkey, nullptr, &result));
+        REQUIRE(result == value);
+    }
+
+#ifdef WIL_ENABLE_EXCEPTIONS
+    SECTION("get and set with string key and DEFAULT value name")
+    {
+        for (DWORD&& value : { 4, 1, 0 })
+        {
+            wil::set_registry_dword(HKEY_CURRENT_USER, testSubkey, nullptr, value);
+            const auto result = wil::get_registry_dword(HKEY_CURRENT_USER, testSubkey, nullptr);
+            REQUIRE(result == value);
+        }
+    }
+#endif
+}

--- a/tests/cpplatest/CMakeLists.txt
+++ b/tests/cpplatest/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 target_sources(witest.cpplatest PUBLIC
     ${COMMON_SOURCES}
     ${COROUTINE_SOURCES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../BasicRegistryTests.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../CppWinRTTests.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../CppWinRT20Tests.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../StlTests.cpp

--- a/tests/noexcept/CMakeLists.txt
+++ b/tests/noexcept/CMakeLists.txt
@@ -12,6 +12,7 @@ append_cxx_flag("/wd4530")
 
 target_sources(witest.noexcept PUBLIC
     ${COMMON_SOURCES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../BasicRegistryTests.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../TokenHelpersTests.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../UniqueWinRTEventTokenTests.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../WatcherTests.cpp

--- a/tests/normal/CMakeLists.txt
+++ b/tests/normal/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(witest)
 
 target_sources(witest PUBLIC
     ${COMMON_SOURCES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../BasicRegistryTests.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../StlTests.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../TokenHelpersTests.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../UniqueWinRTEventTokenTests.cpp

--- a/tests/win7/CMakeLists.txt
+++ b/tests/win7/CMakeLists.txt
@@ -6,6 +6,7 @@ add_definitions("-D_WIN32_WINNT=0x0601")
 
 target_sources(witest.win7 PUBLIC
     ${COMMON_SOURCES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../BasicRegistryTests.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../StlTests.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../TokenHelpersTests.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../WatcherTests.cpp


### PR DESCRIPTION
Today, WIL ships with a registry watcher, but no simple access helpers. This change introduces basic access APIs for common patterns:

* `create_registry_key` & `open_registry_key`
* `set_registry_dword` & `set_registry_string` (and `_nothrow` and `_failfast` variants)
* `get_registry_dword` & `get_registry_string` (only `_nothrow` variant for DWORD, no variants for string due to exception requirements).
* `try_get_registry_dword` & `try_get_registry_string`

There is plenty of room for more helpers, especially for the remaining registry types, but these types are so common it makes sense to at least start with these.

## What changed?

* Introduced new helpers.
* Added new test.

Notably:

* The `try_` functions use `std::optional`, for easier access. They require exceptions and C++17.
* `get_registry_string` always requires exceptions. They return only `std::wstring`, no other string types.
* `set_registry_string` always requires `std::wstring`, since no other type is guaranteed to be null-terminated AND has easy programmatic access to length. (We could rewrite this with a string helper class that grabs length for different types of strings...).

## Open questions

* Can we support more string types (`AdaptFixedSizeToAllocatedResult`)?
* Can we support strings without exceptions?
* Is using `std::optional` too big a divergence from existing impls?
* Do we need to support more registry types?
* Do we need to support "any" result (via std::variant?)
* Do we need to support other registry functions (delete, etc)
* Should we add overloads for DEFAULT values (with no value name, instead of requiring a nullptr)?
* Should we simplify options by introducing enums, etc? e.g. for big-endian/little-endian, or for key rights?
* Are the function pointers bad?

## How tested?

* [x] New tests pass
* [x] Consumed in code---correctly reads registry strings in production